### PR TITLE
Fix deprecated shell_out

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-default[:liquibase][:version]      = "2.0.4"
-default[:liquibase][:url]          = "https://github.com/downloads/liquibase/liquibase/liquibase-#{node[:liquibase][:version]}-bin.tar.gz"
-default[:liquibase][:checksum]     = "1e0586333edae8b45d78b274e1a5d5dc"
+default[:liquibase][:version]      = "3.1.1"
+default[:liquibase][:url]          = "http://softlayer-dal.dl.sourceforge.net/project/liquibase/Liquibase%20Core/liquibase-#{node[:liquibase][:version]}-bin.tar.gz"
+default[:liquibase][:checksum]     = "91c237126ad37703e8e04bb49235044c"
 default[:liquibase][:install_path] = "/opt/liquibase-#{node[:liquibase][:version]}"

--- a/providers/migrate.rb
+++ b/providers/migrate.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-require 'chef/shell_out'
+require 'mixlib/shellout'
 require 'shellwords'
 
 def load_current_resource
@@ -46,7 +46,6 @@ private
   def perform_migrate
     cmd = liquibase_cmd("update")
     cmd.run_command
-
     unless cmd.status.exitstatus == 0
       Chef::Log.fatal cmd.stderr
       Chef::Log.fatal cmd.stdout
@@ -72,13 +71,12 @@ private
     Chef::Log.info "[liquibase] Checking to see if database needs migrating."
     cmd = liquibase_cmd("status")
     cmd.run_command
-
-    cmd.stderr.match(/is up to date/).nil?
+    cmd.stdout.match(/is up to date/).nil?
   end
 
   def liquibase_cmd(*args)
     options = default_options + args + change_log_properties
-    Chef::ShellOut.new(options, :cwd => new_resource.cwd)
+    Mixlib::ShellOut.new(options, :env => {'LC_ALL' => 'en_US.UTF-8'} ,:cwd => new_resource.cwd)
   end
   
   def default_options


### PR DESCRIPTION
Fix deprecated gem (mixlib/shellout instead of chef/shell_out)
Fix status message inspection,
Fix shellout env LC_ALL to «en_US.UTF-8» instead of default «C».
Change default version of liquibase to 3.1.1
