### PR TITLE
Feature/use driver properties file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ adapter                    | Database adapter                                   
 contexts                   | Contexts to run the migrations in                                                                                   | String  | live
 cwd                        | The directory to run the migrations from                                                                            | String  | 
 change_log_properties      | A hash where the keys are property names and the values are property values for substitution into the change log(s) | Hash    | {}
+driver_properties_file     | The location of the driverPropertiesFile. If exists, the password retrieved from there                              | String  |

--- a/providers/migrate.rb
+++ b/providers/migrate.rb
@@ -95,7 +95,7 @@ private
     if new_resource.driver_properties_file
       options << "--driverPropertiesFile=#{Shellwords.escape(new_resource.driver_properties_file)}"
     else
-      options << "--password=#{Shellwords.escape(new_resource.connection[:password]})"
+      options << "--password=#{Shellwords.escape(new_resource.connection[:password])}"
     end
       
     if new_resource.contexts

--- a/providers/migrate.rb
+++ b/providers/migrate.rb
@@ -23,7 +23,7 @@ require 'mixlib/shellout'
 require 'shellwords'
 
 def load_current_resource
-  new_resource.connection[:port] ||= 3306
+  new_resource.connection[:port] ||= 3306 if new_resource.connection
   @current_resource = Chef::Resource::LiquibaseMigrate.new(new_resource.name)
 end
 
@@ -45,6 +45,7 @@ private
 
   def perform_migrate
     cmd = liquibase_cmd("update")
+    Chef::Log.info cmd
     cmd.run_command
     unless cmd.status.exitstatus == 0
       Chef::Log.fatal cmd.stderr
@@ -84,14 +85,19 @@ private
       "/usr/bin/java",
       "-jar",
       liquibase_jar,
-      "--driver=#{Shellwords.escape(new_resource.driver)}",
       "--classpath=#{Shellwords.escape(new_resource.classpath)}",
       "--changeLogFile=#{Shellwords.escape(new_resource.change_log_file)}",
+      "--driver=#{Shellwords.escape(new_resource.driver)}",
       "--url=#{Shellwords.escape(new_resource.connection_url)}",
-      "--username=#{Shellwords.escape(new_resource.connection[:username])}",
-      "--password=#{Shellwords.escape(new_resource.connection[:password])}"
+      "--username=#{Shellwords.escape(new_resource.connection[:username])}"
     ]
-
+    
+    if new_resource.driver_properties_file
+      options << "--driverPropertiesFile=#{Shellwords.escape(new_resource.driver_properties_file)}"
+    else
+      options << "--password=#{Shellwords.escape(new_resource.connection[:password]})"
+    end
+      
     if new_resource.contexts
       contexts = if new_resource.contexts.is_a?(Array)
         new_resource.contexts.split(",")

--- a/resources/migrate.rb
+++ b/resources/migrate.rb
@@ -20,6 +20,7 @@
 #
 
 actions :run, :force
+default_action :create
 
 attribute :change_log_file,       :kind_of => String, :name_attribute => true
 attribute :jar,                   :kind_of => String

--- a/resources/migrate.rb
+++ b/resources/migrate.rb
@@ -22,16 +22,16 @@
 actions :run, :force
 default_action :create
 
-attribute :change_log_file,       :kind_of => String, :name_attribute => true
-attribute :jar,                   :kind_of => String
-attribute :connection,            :kind_of => Hash
-attribute :classpath,             :kind_of => String, :required => true
-attribute :driver,                :kind_of => String, :default => "com.mysql.jdbc.Driver"
-attribute :driver_properties_file	:kind_of => String
-attribute :adapter,               :kind_of => Symbol, :default => :mysql
-attribute :contexts,              :kind_of => [String, Array]
-attribute :cwd,                   :kind_of => String
-attribute :change_log_properties, :kind_of => Hash, :default => Hash.new
+attribute :change_log_file,        :kind_of => String, :name_attribute => true
+attribute :jar,                    :kind_of => String
+attribute :connection,             :kind_of => Hash
+attribute :classpath,              :kind_of => String, :required => true
+attribute :driver,                 :kind_of => String, :default => "com.mysql.jdbc.Driver"
+attribute :driver_properties_file, :kind_of => String
+attribute :adapter,                :kind_of => Symbol, :default => :mysql
+attribute :contexts,               :kind_of => [String, Array]
+attribute :cwd,                    :kind_of => String
+attribute :change_log_properties,  :kind_of => Hash, :default => Hash.new
 
 def initialize(*args)
   super

--- a/resources/migrate.rb
+++ b/resources/migrate.rb
@@ -23,9 +23,10 @@ actions :run, :force
 
 attribute :change_log_file,       :kind_of => String, :name_attribute => true
 attribute :jar,                   :kind_of => String
-attribute :connection,            :kind_of => Hash, :required => true
+attribute :connection,            :kind_of => Hash
 attribute :classpath,             :kind_of => String, :required => true
 attribute :driver,                :kind_of => String, :default => "com.mysql.jdbc.Driver"
+attribute :driver_properties_file	:kind_of => String
 attribute :adapter,               :kind_of => Symbol, :default => :mysql
 attribute :contexts,              :kind_of => [String, Array]
 attribute :cwd,                   :kind_of => String


### PR DESCRIPTION
Ability to get the password from the properties file instead of passing it via command line. This will avoid problems when using symbols in passwords (Shellwords is used to scape the password if the parameter is passed in the CLI)
