### PR TITLE
Avoid double-escaping of parameters

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       "Riot Games"
 maintainer_email "bluepojo@gmail.com"
 license          "Apache 2.0"
 description      "Installs and configures Liquibase"
-version          "1.0.0"
+version          "1.0.1"
 
 %w{ centos redhat fedora }.each do |os|
   supports os

--- a/providers/migrate.rb
+++ b/providers/migrate.rb
@@ -76,7 +76,7 @@ private
 
   def liquibase_cmd(*args)
     options = default_options + args + change_log_properties
-    Mixlib::ShellOut.new(options, :env => {'LC_ALL' => 'en_US.UTF-8'} ,:cwd => new_resource.cwd)
+    Mixlib::ShellOut.new(options.join(' '), :env => {'LC_ALL' => 'en_US.UTF-8'} ,:cwd => new_resource.cwd)
   end
   
   def default_options


### PR DESCRIPTION
According to Kernel.exec documentation shell expansion will only occur when command is supplied as a string and will NOT occur when command is supplied as an array
