### PR TITLE
Support passwordless migrations

### DIFF
--- a/providers/migrate.rb
+++ b/providers/migrate.rb
@@ -88,9 +88,12 @@ private
       "--classpath=#{Shellwords.escape(new_resource.classpath)}",
       "--changeLogFile=#{Shellwords.escape(new_resource.change_log_file)}",
       "--url=#{Shellwords.escape(new_resource.connection_url)}",
-      "--username=#{Shellwords.escape(new_resource.connection[:username])}",
-      "--password=#{Shellwords.escape(new_resource.connection[:password])}"
+      "--username=#{Shellwords.escape(new_resource.connection[:username])}"
     ]
+
+    unless new_resource.connection[:password].nil?
+      options << "--password=#{Shellwords.escape(new_resource.connection[:password])}"
+    end
 
     if new_resource.contexts
       contexts = if new_resource.contexts.is_a?(Array)


### PR DESCRIPTION
Hey guys,

I found out in the current cookbook's version there is no way to migrate database without password, e.g. in local development vagrant environments etc. Apparently it's well supported by Liquibase, but not by the LWRP. 

If you specify the `connection[:password]` to be `nil`, the script will try to run liquibase without the `--password` parameter. Currently, the LWRP fails with a thrown Exception in such case. Other than that, the update should not change anything.

Best regards,
Kamil

BTW: Thanks for your great work on that cookbook!
